### PR TITLE
feat: add project setup templates (CLAUDE.md + settings.json)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,14 @@ A Claude Code plugin marketplace with 3 focused plugins for Java developers. All
 | `java-spring` | 4 | 2 | `java-spring-expert` | Spring Boot projects |
 | `java-quality` | 3 | 1 | `java-security-reviewer`, `java-performance-reviewer`, `java-test-engineer` | Quality enforcement |
 
+## Quick Setup (5 minutes)
+
+1. Copy [`templates/CLAUDE.md.template`](templates/CLAUDE.md.template) to your Java project root as `CLAUDE.md` and fill in the placeholders
+2. Copy [`templates/settings.json.template`](templates/settings.json.template) to `.claude/settings.local.json` to pre-approve build/test commands
+3. Install the plugins (below)
+
+---
+
 ## Installation
 
 ### Step 1 — Add the marketplace

--- a/templates/CLAUDE.md.template
+++ b/templates/CLAUDE.md.template
@@ -1,0 +1,116 @@
+# CLAUDE.md — Java Project
+
+<!--
+  HOW TO USE THIS TEMPLATE
+  ========================
+  1. Copy this file to the root of your Java project as CLAUDE.md
+  2. Fill in the sections marked with [REPLACE: ...]
+  3. Install the plugins (see Plugins section below)
+  4. Delete this comment block
+
+  Plugins used by this template:
+    /plugin marketplace add ducpm2303/claude-java-plugins
+    /plugin install java-core@java-plugins
+    /plugin install java-spring@java-plugins     # remove if not a Spring Boot project
+    /plugin install java-quality@java-plugins
+-->
+
+## Project
+
+**Name:** [REPLACE: e.g. order-service]
+**Java version:** [REPLACE: 8 / 11 / 17 / 21]
+**Spring Boot version:** [REPLACE: 2.7.x / 3.2.x / 3.3.x — remove if not Spring Boot]
+**Build tool:** [REPLACE: Maven / Gradle]
+**Base package:** [REPLACE: e.g. com.example.orders]
+
+## Build & Run Commands
+
+```bash
+# Build
+[REPLACE: mvn clean package  OR  ./gradlew clean build]
+
+# Run tests
+[REPLACE: mvn test  OR  ./gradlew test]
+
+# Run tests with coverage
+[REPLACE: mvn test jacoco:report  OR  ./gradlew test jacocoTestReport]
+
+# Start the application
+[REPLACE: mvn spring-boot:run  OR  ./gradlew bootRun]
+
+# Start local database (if applicable)
+[REPLACE: docker run -p 5432:5432 -e POSTGRES_PASSWORD=postgres postgres:16-alpine]
+```
+
+## Preferred Workflows
+
+When I ask for help, use these skills from the installed plugins:
+
+- **Code review** → `/java-core:java-review`
+- **Fix compile errors / stack traces** → `/java-core:java-fix`
+- **Refactor** → `/java-core:java-refactor`
+- **Generate tests** → `/java-quality:java-test`
+- **Security scan** → `/java-quality:java-security-check`
+- **Performance scan** → `/java-quality:java-perf-check`
+- **Full quality audit** → `/java-quality:audit`
+- **CRUD feature** → `/java-spring:java-crud` *(Spring Boot projects only)*
+- **JPA review** → `/java-spring:java-jpa` *(Spring Boot projects only)*
+- **Commit message** → `/java-core:java-commit`
+
+For architectural questions, delegate to the `java-architect` agent.
+For deep security audits, delegate to the `java-security-reviewer` agent.
+
+## Coding Standards
+
+The plugins enforce these automatically — listed here as a reminder:
+
+- Constructor injection only (`final` fields, no `@Autowired` on fields)
+- `@Transactional(readOnly = true)` on all read-only service methods
+- Return `ResponseEntity<T>` from all controller methods
+- Validate `@RequestBody` with `@Valid`
+- Never log passwords, tokens, or PII
+- Use `jakarta.persistence.*` (Spring Boot 3.x+) or `javax.persistence.*` (2.x)
+
+[REPLACE: add any project-specific conventions here]
+
+## Architecture
+
+[REPLACE: brief description, e.g.:]
+```
+Controller → Service → Repository (layered)
+Packages: controller / service / repository / entity / dto / exception / config
+Database: PostgreSQL (Testcontainers for integration tests)
+```
+
+## Key Files
+
+[REPLACE: point Claude to important files it should know about, e.g.:]
+```
+src/main/resources/application.yml     — main config
+src/main/java/.../exception/           — global exception handler
+src/main/java/.../config/              — Spring configuration classes
+```
+
+## What NOT to Do
+
+- Do not modify `pom.xml` / `build.gradle` dependencies without confirming with me
+- Do not change `application.yml` database credentials
+- Do not commit directly to `main` — always use a feature branch
+- [REPLACE: add project-specific restrictions]
+
+## Testing Strategy
+
+- Unit tests: JUnit 5 + Mockito, files named `*Test.java`
+- Integration tests: Testcontainers + `@SpringBootTest`, files named `*IT.java`
+- Run tests before marking any task complete: `[REPLACE: mvn test OR ./gradlew test]`
+- Minimum coverage target: 80% on the service layer
+
+## Environment Variables
+
+[REPLACE: list required env vars so Claude knows not to hardcode them, e.g.:]
+```
+DATABASE_URL      — JDBC connection string
+DATABASE_USER     — database username
+DATABASE_PASSWORD — database password
+JWT_SECRET        — JWT signing key
+```

--- a/templates/README.md
+++ b/templates/README.md
@@ -1,0 +1,41 @@
+# Templates
+
+Copy-paste templates for setting up Claude Code in your Java project.
+
+## CLAUDE.md.template
+
+The main project briefing file that Claude loads at the start of every session.
+
+**Setup (5 minutes):**
+1. Copy to your Java project root as `CLAUDE.md`
+2. Fill in the `[REPLACE: ...]` placeholders
+3. Delete the comment block at the top
+
+**What it does:**
+- Tells Claude your Java/Spring Boot version so it uses the right idioms
+- Points Claude to your build commands so it can verify changes
+- Sets preferred skills for common tasks (review, test, security scan)
+- Lists environment variables so Claude never hardcodes them
+- Defines what Claude should NOT do in your project
+
+## settings.json.template
+
+Pre-approved shell commands so Claude doesn't prompt for permission on every build or test run.
+
+**Setup:**
+1. Copy to your Java project root as `.claude/settings.local.json`
+2. Adjust the `allow` list to match your build tool (Maven or Gradle)
+3. Keep the `deny` list — it blocks force-push, hard reset, and test-skip flags
+
+**Note:** `settings.local.json` is gitignored by default. Use `settings.json` if you want to commit these approvals for the whole team.
+
+## java-pr-review.yml
+
+GitHub Actions workflow for automated Java PR reviews.
+
+**Setup:**
+1. Copy to `.github/workflows/java-pr-review.yml` in your Java project
+2. Add `ANTHROPIC_API_KEY` to your repo secrets
+3. Every PR touching `.java` or build files gets a security + performance + code quality review posted as a comment
+
+See the [main README](../README.md#github-actions--automated-pr-review) for details.

--- a/templates/settings.json.template
+++ b/templates/settings.json.template
@@ -1,0 +1,42 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(mvn clean package)",
+      "Bash(mvn test)",
+      "Bash(mvn test jacoco:report)",
+      "Bash(mvn spring-boot:run)",
+      "Bash(mvn spotbugs:check)",
+      "Bash(mvn checkstyle:check)",
+      "Bash(mvn pmd:check)",
+      "Bash(mvn dependency:tree)",
+      "Bash(./gradlew clean build)",
+      "Bash(./gradlew test)",
+      "Bash(./gradlew test jacocoTestReport)",
+      "Bash(./gradlew bootRun)",
+      "Bash(./gradlew spotbugsMain)",
+      "Bash(./gradlew checkstyleMain)",
+      "Bash(./gradlew pmdMain)",
+      "Bash(./gradlew dependencies)",
+      "Bash(git status)",
+      "Bash(git diff*)",
+      "Bash(git log*)",
+      "Bash(git add*)",
+      "Bash(git commit*)",
+      "Bash(git checkout*)",
+      "Bash(git branch*)",
+      "Bash(find src -name '*.java'*)",
+      "Bash(grep -r* src/)",
+      "Bash(docker ps)",
+      "Bash(docker run*postgres*)"
+    ],
+    "deny": [
+      "Bash(git push --force*)",
+      "Bash(git reset --hard*)",
+      "Bash(mvn*-Dmaven.test.skip=true*)",
+      "Bash(./gradlew*-x test*)",
+      "Bash(rm -rf*)",
+      "Bash(drop table*)",
+      "Bash(DROP TABLE*)"
+    ]
+  }
+}


### PR DESCRIPTION
templates/CLAUDE.md.template:
- Ready-to-use CLAUDE.md for any Java/Spring Boot project
- Covers: Java/Spring Boot version, build commands, preferred skills, coding standards, architecture, key files, env vars, testing strategy
- [REPLACE: ...] placeholders for project-specific values
- Wires all installed java-plugins skills as preferred workflows

templates/settings.json.template:
- Pre-approved Maven + Gradle commands (no permission prompts)
- Deny list blocks force-push, hard reset, and test-skip flags
- Copy to .claude/settings.local.json

templates/README.md:
- Explains each template and setup steps

README: added Quick Setup section at the top (5-minute onboarding)