### PR TITLE
fix: remove unsupported commands/rules fields from plugin.json manifests

### DIFF
--- a/plugins/java-core/.claude-plugin/plugin.json
+++ b/plugins/java-core/.claude-plugin/plugin.json
@@ -5,7 +5,5 @@
   "author": {
     "name": "java-plugins contributors"
   },
-  "keywords": ["java", "review", "refactor", "explain", "fix", "docs"],
-  "commands": ["commands/*.md"],
-  "rules": ["rules/*.md"]
+  "keywords": ["java", "review", "refactor", "explain", "fix", "docs"]
 }

--- a/plugins/java-quality/.claude-plugin/plugin.json
+++ b/plugins/java-quality/.claude-plugin/plugin.json
@@ -5,7 +5,5 @@
   "author": {
     "name": "java-plugins contributors"
   },
-  "keywords": ["java", "security", "owasp", "performance", "testing", "junit", "mockito", "testcontainers"],
-  "commands": ["commands/*.md"],
-  "rules": ["rules/*.md"]
+  "keywords": ["java", "security", "owasp", "performance", "testing", "junit", "mockito", "testcontainers"]
 }

--- a/plugins/java-spring/.claude-plugin/plugin.json
+++ b/plugins/java-spring/.claude-plugin/plugin.json
@@ -5,7 +5,5 @@
   "author": {
     "name": "java-plugins contributors"
   },
-  "keywords": ["java", "spring", "spring-boot", "scaffold", "rest", "jpa"],
-  "commands": ["commands/*.md"],
-  "rules": ["rules/*.md"]
+  "keywords": ["java", "spring", "spring-boot", "scaffold", "rest", "jpa"]
 }


### PR DESCRIPTION
Claude Code plugin.json does not accept "commands" or "rules" glob declarations — these directories are auto-discovered by convention. Adding them caused "Validation errors: commands: Invalid input" on plugin load for java-core and java-quality.