### PR TITLE
fix: correct .lsp.json schema for jdtls

### DIFF
--- a/plugins/java-core/.lsp.json
+++ b/plugins/java-core/.lsp.json
@@ -1,33 +1,8 @@
 {
   "lspServers": {
-    "java": {
-      "command": "jdtls",
-      "args": [],
-      "initializationOptions": {
-        "settings": {
-          "java": {
-            "format": {
-              "enabled": true,
-              "settings": {
-                "profile": "GoogleStyle"
-              }
-            },
-            "saveActions": {
-              "organizeImports": true
-            },
-            "completion": {
-              "importOrder": ["java", "javax", "jakarta", "org", "com"]
-            },
-            "inlayHints": {
-              "parameterNames": {
-                "enabled": "all"
-              }
-            }
-          }
-        }
-      },
-      "filetypes": ["java"],
-      "notes": "Requires Eclipse JDT Language Server (jdtls). Install via: brew install jdtls (macOS), or https://github.com/eclipse-jdtls/eclipse.jdt.ls"
+    "command": "jdtls",
+    "extensionToLanguage": {
+      ".java": "java"
     }
   }
 }


### PR DESCRIPTION
Claude Code expects lspServers.command (string) and lspServers.extensionToLanguage (record) directly — not nested under a language key. The previous "java": { command, ... } structure caused "Unrecognized key: java" and "expected string, received undefined" errors.