### PR TITLE
feat(java-spring): add java-openapi skill

### DIFF
--- a/plugins/java-spring/skills/java-openapi/SKILL.md
+++ b/plugins/java-spring/skills/java-openapi/SKILL.md
@@ -1,0 +1,125 @@
+---
+description: Generates or reviews OpenAPI / Swagger documentation for Spring Boot REST APIs — adds @Operation, @Schema, @ApiResponse annotations and configures Swagger UI. Use when user asks to "add Swagger", "document this API", "generate OpenAPI spec", "add @Operation annotations", "set up Swagger UI", or "document endpoints".
+argument-hint: "[generate | review | config] [Spring Boot version]"
+allowed-tools: Read, Grep, Glob
+---
+
+# /java-openapi — OpenAPI / Swagger Documentation
+
+You are an OpenAPI documentation specialist for Spring Boot. Generate annotations, review existing docs, or configure Swagger UI.
+
+## Step 1 — Detect context
+
+1. Check Spring Boot version and choose the right library:
+   - Spring Boot 3.x → `springdoc-openapi-starter-webmvc-ui` (v2.x)
+   - Spring Boot 2.x → `springdoc-openapi-ui` (v1.x)
+2. Check if `springdoc` is already on the classpath
+3. Determine mode from argument: `generate` (default), `review`, or `config`
+
+---
+
+## Step 2 — Add dependency (if not present)
+
+Show the user the correct dependency to add:
+
+**Spring Boot 3.x (`pom.xml`):**
+```xml
+<dependency>
+    <groupId>org.springdoc</groupId>
+    <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+    <version>2.5.0</version>
+</dependency>
+```
+
+**Spring Boot 2.x (`pom.xml`):**
+```xml
+<dependency>
+    <groupId>org.springdoc</groupId>
+    <artifactId>springdoc-openapi-ui</artifactId>
+    <version>1.8.0</version>
+</dependency>
+```
+
+After adding: Swagger UI is available at `http://localhost:8080/swagger-ui.html`.
+
+---
+
+## Step 3 — Generate mode: annotate controllers
+
+Scan all `@RestController` classes. For each one, add annotations following the rules below.
+
+**Controller class level — `@Tag`:**
+```java
+@Tag(name = "Products", description = "Product catalogue management")
+@RestController
+@RequestMapping("/api/products")
+public class ProductController { ... }
+```
+
+**Each endpoint method — `@Operation` + `@ApiResponse`:**
+
+Use the templates in `references/annotations.md`. Key rules:
+- `@Operation(summary = ...)` — one short line, verb phrase (e.g. "Get product by ID")
+- `@Operation(description = ...)` — optional, only when behaviour is non-obvious
+- Always document: `200`, the main error codes (`400`, `404`, `409`, `500`)
+- Use `@ApiResponse(responseCode = "404", description = "Product not found")` not just the status code
+
+**Request/Response DTOs — `@Schema`:**
+- Annotate every field with `@Schema(description = "...", example = "...")`
+- For required fields: `@Schema(requiredMode = Schema.RequiredMode.REQUIRED)`
+- For enums: `@Schema(allowableValues = {"ACTIVE", "INACTIVE"})`
+
+---
+
+## Step 4 — Review mode: audit existing docs
+
+Check for these issues:
+
+| Issue | Severity |
+|---|---|
+| `@Operation` with empty or generic summary ("string", "TODO") | HIGH |
+| Missing `@ApiResponse` for error codes the method actually throws | HIGH |
+| DTO fields with no `@Schema` description | MEDIUM |
+| No `@Tag` on controller class | MEDIUM |
+| Sensitive fields exposed in response schema (passwords, tokens) | HIGH |
+| `@Hidden` missing on internal/admin endpoints that shouldn't be in public docs | MEDIUM |
+
+---
+
+## Step 5 — Config mode: OpenAPI bean + Swagger UI setup
+
+Use the config template in `references/annotations.md`. Covers:
+- Global API info (title, version, description, contact, license)
+- Security scheme (Bearer JWT in "Authorize" button)
+- Environment-specific Swagger UI (disable in production)
+
+**application.yml for Swagger UI:**
+```yaml
+springdoc:
+  api-docs:
+    path: /api-docs
+  swagger-ui:
+    path: /swagger-ui.html
+    operations-sorter: method
+    tags-sorter: alpha
+  # Disable in production:
+  # swagger-ui.enabled: false
+  # api-docs.enabled: false
+```
+
+---
+
+## Step 6 — Post-generation checklist
+
+- [ ] Swagger UI loads at `/swagger-ui.html`
+- [ ] All controllers have `@Tag`
+- [ ] All endpoints have `@Operation(summary = ...)`
+- [ ] All error responses are documented
+- [ ] JWT "Authorize" button works (if security is configured)
+- [ ] Sensitive fields are not in public API docs (`@JsonIgnore` or `@Schema(hidden = true)`)
+
+## Next Steps
+
+- Review REST API design → `/java-api-review`
+- Add Spring Security → `/java-security`
+- Review the full service → `/java-review`

--- a/plugins/java-spring/skills/java-openapi/references/annotations.md
+++ b/plugins/java-spring/skills/java-openapi/references/annotations.md
@@ -1,0 +1,159 @@
+# OpenAPI Annotation Templates
+
+---
+
+## Controller with full annotations
+
+```java
+@Tag(name = "Products", description = "Product catalogue management")
+@RestController
+@RequestMapping("/api/products")
+@RequiredArgsConstructor
+public class ProductController {
+
+    private final ProductService productService;
+
+    @Operation(summary = "List all products",
+               description = "Returns a paginated list. Use `page` and `size` query params.")
+    @ApiResponse(responseCode = "200", description = "Page of products")
+    @GetMapping
+    public ResponseEntity<Page<ProductResponse>> findAll(Pageable pageable) { ... }
+
+    @Operation(summary = "Get product by ID")
+    @ApiResponse(responseCode = "200", description = "Product found")
+    @ApiResponse(responseCode = "404", description = "Product not found")
+    @GetMapping("/{id}")
+    public ResponseEntity<ProductResponse> findById(@PathVariable Long id) { ... }
+
+    @Operation(summary = "Create a new product")
+    @ApiResponse(responseCode = "201", description = "Product created",
+                 content = @Content(schema = @Schema(implementation = ProductResponse.class)))
+    @ApiResponse(responseCode = "400", description = "Validation failed")
+    @ApiResponse(responseCode = "409", description = "Product with this SKU already exists")
+    @PostMapping
+    public ResponseEntity<ProductResponse> create(@Valid @RequestBody ProductRequest request) { ... }
+
+    @Operation(summary = "Update product")
+    @ApiResponse(responseCode = "200", description = "Product updated")
+    @ApiResponse(responseCode = "400", description = "Validation failed")
+    @ApiResponse(responseCode = "404", description = "Product not found")
+    @PutMapping("/{id}")
+    public ResponseEntity<ProductResponse> update(@PathVariable Long id,
+                                                   @Valid @RequestBody ProductRequest request) { ... }
+
+    @Operation(summary = "Delete product")
+    @ApiResponse(responseCode = "204", description = "Product deleted")
+    @ApiResponse(responseCode = "404", description = "Product not found")
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable Long id) { ... }
+}
+```
+
+---
+
+## DTO with @Schema annotations
+
+```java
+// Request DTO
+public record ProductRequest(
+
+    @Schema(description = "Product display name", example = "Wireless Mouse", requiredMode = REQUIRED)
+    @NotBlank String name,
+
+    @Schema(description = "Unit price in USD", example = "29.99", minimum = "0")
+    @NotNull @DecimalMin("0.00") BigDecimal price,
+
+    @Schema(description = "Product category", example = "ELECTRONICS",
+            allowableValues = {"ELECTRONICS", "CLOTHING", "FOOD"})
+    @NotNull String category,
+
+    @Schema(description = "Whether the product is available for purchase", example = "true")
+    boolean active
+
+) {}
+
+// Response DTO
+public record ProductResponse(
+
+    @Schema(description = "Unique product identifier", example = "42")
+    Long id,
+
+    @Schema(description = "Product display name", example = "Wireless Mouse")
+    String name,
+
+    @Schema(description = "Unit price in USD", example = "29.99")
+    BigDecimal price,
+
+    @Schema(description = "Product category", example = "ELECTRONICS")
+    String category,
+
+    @Schema(description = "Availability status", example = "true")
+    boolean active,
+
+    @Schema(description = "ISO-8601 creation timestamp", example = "2024-01-15T10:30:00Z")
+    LocalDateTime createdAt
+
+) {}
+```
+
+---
+
+## OpenAPI global config bean
+
+```java
+@Configuration
+public class OpenApiConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+            .info(new Info()
+                .title("My Service API")
+                .version("v1.0")
+                .description("REST API for My Service")
+                .contact(new Contact()
+                    .name("API Support")
+                    .email("api@example.com"))
+                .license(new License()
+                    .name("Apache 2.0")
+                    .url("https://www.apache.org/licenses/LICENSE-2.0")))
+            // JWT Bearer auth in Swagger UI "Authorize" button
+            .addSecurityItem(new SecurityRequirement().addList("bearerAuth"))
+            .components(new Components()
+                .addSecuritySchemes("bearerAuth", new SecurityScheme()
+                    .type(SecurityScheme.Type.HTTP)
+                    .scheme("bearer")
+                    .bearerFormat("JWT")
+                    .description("Paste your JWT access token here")));
+    }
+}
+```
+
+---
+
+## Hide internal endpoints from public docs
+
+```java
+// Hide entire controller
+@Hidden
+@RestController
+@RequestMapping("/internal")
+public class InternalController { ... }
+
+// Hide one endpoint
+@Operation(hidden = true)
+@GetMapping("/admin/debug")
+public ResponseEntity<DebugInfo> debug() { ... }
+```
+
+---
+
+## application.yml — production safety
+
+```yaml
+springdoc:
+  swagger-ui:
+    enabled: ${SWAGGER_ENABLED:false}    # false in prod, true in dev
+  api-docs:
+    enabled: ${SWAGGER_ENABLED:false}
+```


### PR DESCRIPTION
Covers OpenAPI/Swagger documentation for Spring Boot:
- Detect correct springdoc version (v2.x for Boot 3.x, v1.x for Boot 2.x)
- Generate mode: adds @Tag, @Operation, @ApiResponse, @Schema to all controllers and DTOs
- Review mode: audits existing docs for missing/wrong annotations
- Config mode: OpenApiConfig bean with JWT auth scheme, Swagger UI application.yml setup, production disable pattern

references/annotations.md contains full templates for controllers, DTOs, global config, and hidden endpoint patterns.