### PR TITLE
fix: add id-token: write permission for claude-code-action OIDC auth

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -18,6 +18,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
anthropics/claude-code-action@v1 requires id-token: write to fetch an OIDC token for authentication. Without it, the PR review job fails with "Could not fetch an OIDC token."