### PR TITLE
feat(java-spring): add java-event-driven skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A Claude Code plugin marketplace with 3 focused plugins for Java developers. All
 | Plugin | Skills | Commands | Agents | Install when |
 |---|---|---|---|---|
 | `java-core` | 14 | 2 | `java-architect`, `java-build-resolver` | Every Java project |
-| `java-spring` | 9 | 2 | `java-spring-expert` | Spring Boot projects |
+| `java-spring` | 10 | 2 | `java-spring-expert` | Spring Boot projects |
 | `java-quality` | 3 | 1 | `java-security-reviewer`, `java-performance-reviewer`, `java-test-engineer` | Quality enforcement |
 
 ## Quick Setup (5 minutes)
@@ -78,6 +78,7 @@ Skills activate automatically based on context, or invoke them explicitly.
 | `/java-spring:java-spring-ai` | Add AI features to Spring Boot — ChatClient, RAG, tool calling, memory (Spring AI 1.x / LangChain4J) |
 | `/java-spring:java-resilience` | Add Resilience4J patterns — circuit breaker, retry, rate limiter, bulkhead, timeout (Boot 2.x & 3.x) |
 | `/java-spring:java-cache` | Add or review Spring Cache — Caffeine (single-instance) or Redis (distributed), @Cacheable/@CacheEvict/@CachePut |
+| `/java-spring:java-event-driven` | Implement event-driven patterns — Spring App Events, domain events, Kafka, RabbitMQ, outbox pattern |
 
 ### java-quality
 

--- a/plugins/java-spring/skills/java-event-driven/SKILL.md
+++ b/plugins/java-spring/skills/java-event-driven/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: java-event-driven
+description: Use when the user asks to implement event-driven architecture, decouple services with events, use Spring Application Events, integrate Kafka or RabbitMQ, publish domain events, or review existing messaging/eventing code in a Spring Boot project.
+version: 1.0.0
+authors: [java-plugins contributors]
+tags: [java, spring-boot, events, kafka, rabbitmq, event-driven, messaging, domain-events]
+allowed-tools: [Read, Glob, Grep, Edit, Write]
+---
+
+# Event-Driven Skill
+
+Detect the messaging infrastructure in use, then apply the correct pattern.
+
+## Step 1 — Detect setup
+
+Check `pom.xml` or `build.gradle`:
+- `spring-kafka` → Apache Kafka
+- `spring-boot-starter-amqp` → RabbitMQ (AMQP)
+- `spring-cloud-starter-stream-kafka` → Spring Cloud Stream (Kafka binder)
+- `spring-cloud-starter-stream-rabbit` → Spring Cloud Stream (RabbitMQ binder)
+- None of the above → Spring Application Events (in-process, no broker)
+
+---
+
+## Mode: `review`
+
+User asks to review existing event-driven code. Check for:
+
+**Spring Application Events:**
+- [ ] `@EventListener` methods are not `private` — Spring proxies can't intercept private methods
+- [ ] `@Async` on event listeners that do I/O or send emails — synchronous listeners block the publisher
+- [ ] `@TransactionalEventListener(phase = AFTER_COMMIT)` used for post-commit side effects — not plain `@EventListener` (which fires mid-transaction)
+- [ ] Domain events published via `AbstractAggregateRoot.registerEvent()` + `save()` — not manual `ApplicationEventPublisher.publishEvent()` from repositories
+- [ ] No business logic in event publishers — events carry data, not decisions
+
+**Kafka:**
+- [ ] `@KafkaListener` has explicit `groupId` — missing it uses random ID, losing consumer group semantics
+- [ ] Deserialization error handler configured — `DefaultErrorHandler` with `DeadLetterPublishingRecoverer`
+- [ ] `acks=all` and `min.insync.replicas≥2` for producers in production
+- [ ] `enable.auto.commit=false` — use manual ack (`AckMode.MANUAL_IMMEDIATE`) for at-least-once
+- [ ] `@KafkaListener` is idempotent — duplicate messages will be delivered (at-least-once guarantee)
+- [ ] Kafka consumer uses `@Payload` + `@Header` instead of raw `ConsumerRecord` where appropriate
+- [ ] Topic partition count and replication factor set for production (not defaults of 1/1)
+
+**RabbitMQ:**
+- [ ] Queues declared as `durable=true` — survive broker restart
+- [ ] Dead-letter exchange (DLX) configured — failed messages don't disappear
+- [ ] `@RabbitListener` has a `containerFactory` with error handler
+- [ ] `MessageConverter` set to `Jackson2JsonMessageConverter` — not default Java serialization
+- [ ] Prefetch count (`prefetch`) tuned — default 250 is too high for slow consumers
+- [ ] Publisher confirms enabled for critical messages (`spring.rabbitmq.publisher-confirm-type=correlated`)
+
+---
+
+## Mode: `app-events`
+
+User asks to decouple components using Spring Application Events (in-process, no broker needed).
+
+1. Define event class — a simple POJO or `record` extending nothing (Boot 3.x) or `ApplicationEvent` (Boot 2.x)
+2. Inject `ApplicationEventPublisher` into the publisher service
+3. Call `publisher.publishEvent(new MyEvent(...))` after the business operation
+4. Create listener with `@EventListener` — or `@TransactionalEventListener(phase = AFTER_COMMIT)` for post-commit side effects
+5. Add `@Async` + `@EnableAsync` for non-blocking listeners (I/O, emails, notifications)
+
+When to use vs Kafka/RabbitMQ: use app events for in-process decoupling within a single service; use a broker when events must cross service boundaries or survive restarts.
+
+---
+
+## Mode: `domain-events`
+
+User asks to publish domain events from JPA entities (DDD pattern).
+
+1. Entity extends `AbstractAggregateRoot<T>` (Spring Data)
+2. Call `registerEvent(new DomainEvent(...))` inside entity business methods
+3. Events are automatically published by Spring Data when `repository.save(entity)` is called
+4. Listener uses `@TransactionalEventListener(phase = AFTER_COMMIT)` — fires after the transaction commits, not during
+
+This guarantes events are only published when the entity change is persisted — no phantom events on rollback.
+
+---
+
+## Mode: `kafka`
+
+User asks to integrate Apache Kafka.
+
+1. Add `spring-kafka` dependency
+2. Configure `bootstrap-servers`, serializers/deserializers in `application.yml`
+3. Define `@Bean KafkaTemplate<String, T>` for publishing (or use auto-configured one)
+4. Create `@KafkaListener(topics = "...", groupId = "...")` for consuming
+5. Configure `DefaultErrorHandler` with `DeadLetterPublishingRecoverer` for failed messages
+6. For JSON: use `JsonSerializer` / `JsonDeserializer` with trusted packages set
+
+See `references/patterns.md` for full producer/consumer/DLT examples.
+
+---
+
+## Mode: `rabbitmq`
+
+User asks to integrate RabbitMQ.
+
+1. Add `spring-boot-starter-amqp`
+2. Declare exchange, queue, and binding as `@Bean` (or via `@RabbitListener` + `@Queue` annotations)
+3. Configure `Jackson2JsonMessageConverter` bean — set on both template and listener container factory
+4. Use `RabbitTemplate` to publish; `@RabbitListener` to consume
+5. Declare dead-letter exchange + DLQ for failed message handling
+6. Enable publisher confirms for critical messages
+
+See `references/patterns.md` for full exchange/queue/DLX setup and listener examples.
+
+---
+
+## Output format
+
+For **review mode**: list findings as `[CRITICAL] / [HIGH] / [MEDIUM] / [LOW]` with file:line references.
+
+For **implementation modes**: show exact Maven/Gradle dependency, full `application.yml`, and complete Java examples. Note version-specific differences (Boot 2.x vs 3.x, Kafka 3.x API changes).

--- a/plugins/java-spring/skills/java-event-driven/references/patterns.md
+++ b/plugins/java-spring/skills/java-event-driven/references/patterns.md
@@ -1,0 +1,392 @@
+# Event-Driven — Reference Patterns
+
+## Spring Application Events
+
+### Event class (Boot 3.x — plain record)
+```java
+public record OrderPlacedEvent(Long orderId, String customerId, BigDecimal total) {}
+```
+
+### Event class (Boot 2.x — extend ApplicationEvent)
+```java
+public class OrderPlacedEvent extends ApplicationEvent {
+    private final Long orderId;
+    private final String customerId;
+
+    public OrderPlacedEvent(Object source, Long orderId, String customerId) {
+        super(source);
+        this.orderId = orderId;
+        this.customerId = customerId;
+    }
+}
+```
+
+### Publisher
+```java
+@Service
+@RequiredArgsConstructor
+public class OrderService {
+
+    private final OrderRepository repository;
+    private final ApplicationEventPublisher eventPublisher;
+
+    @Transactional
+    public Order placeOrder(OrderRequest request) {
+        Order order = repository.save(Order.from(request));
+        // Publish AFTER saving — but still inside transaction
+        eventPublisher.publishEvent(new OrderPlacedEvent(order.getId(), request.getCustomerId(), order.getTotal()));
+        return order;
+    }
+}
+```
+
+### Synchronous listener
+```java
+@Component
+@Slf4j
+public class OrderEventListener {
+
+    @EventListener
+    public void onOrderPlaced(OrderPlacedEvent event) {
+        log.info("Order placed: {}", event.orderId());
+        // runs in same thread, same transaction as publisher
+    }
+}
+```
+
+### Async listener (non-blocking I/O)
+```java
+@Configuration
+@EnableAsync
+public class AsyncConfig {}
+
+@Component
+@Slf4j
+public class NotificationListener {
+
+    @Async
+    @EventListener
+    public void sendConfirmationEmail(OrderPlacedEvent event) {
+        // runs in separate thread — publisher doesn't wait
+        emailService.sendOrderConfirmation(event.customerId(), event.orderId());
+    }
+}
+```
+
+### Post-commit listener (fires AFTER transaction commits)
+```java
+@Component
+@Slf4j
+public class AuditListener {
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void auditOrderPlaced(OrderPlacedEvent event) {
+        // Safe — only fires if transaction committed successfully
+        auditLog.record("ORDER_PLACED", event.orderId());
+    }
+}
+```
+
+---
+
+## Domain Events via AbstractAggregateRoot
+
+```java
+@Entity
+public class Order extends AbstractAggregateRoot<Order> {
+
+    @Id @GeneratedValue
+    private Long id;
+    private OrderStatus status;
+
+    public Order confirm() {
+        this.status = OrderStatus.CONFIRMED;
+        registerEvent(new OrderConfirmedEvent(this.id));  // queued, not published yet
+        return this;
+    }
+}
+
+// In service — events published automatically after save()
+@Transactional
+public Order confirmOrder(Long orderId) {
+    Order order = repository.findById(orderId).orElseThrow();
+    order.confirm();
+    return repository.save(order);  // ← events published here by Spring Data
+}
+```
+
+---
+
+## Kafka
+
+### Maven
+```xml
+<dependency>
+  <groupId>org.springframework.kafka</groupId>
+  <artifactId>spring-kafka</artifactId>
+</dependency>
+```
+
+### application.yml
+```yaml
+spring:
+  kafka:
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+      acks: all
+      properties:
+        enable.idempotence: true
+        max.in.flight.requests.per.connection: 5
+    consumer:
+      group-id: order-service
+      auto-offset-reset: earliest
+      enable-auto-commit: false
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+      properties:
+        spring.json.trusted.packages: "com.example.events"
+    listener:
+      ack-mode: MANUAL_IMMEDIATE
+```
+
+### Producer
+```java
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class OrderEventProducer {
+
+    private final KafkaTemplate<String, OrderPlacedEvent> kafkaTemplate;
+
+    public void publishOrderPlaced(OrderPlacedEvent event) {
+        kafkaTemplate.send("orders.placed", event.orderId().toString(), event)
+            .whenComplete((result, ex) -> {
+                if (ex != null) {
+                    log.error("Failed to publish OrderPlacedEvent for order {}", event.orderId(), ex);
+                } else {
+                    log.debug("Published OrderPlacedEvent: partition={}, offset={}",
+                        result.getRecordMetadata().partition(),
+                        result.getRecordMetadata().offset());
+                }
+            });
+    }
+}
+```
+
+### Consumer with manual ack + DLT
+```java
+@Component
+@Slf4j
+public class OrderEventConsumer {
+
+    @KafkaListener(topics = "orders.placed", groupId = "notification-service")
+    public void handleOrderPlaced(
+            @Payload OrderPlacedEvent event,
+            @Header(KafkaHeaders.RECEIVED_PARTITION) int partition,
+            @Header(KafkaHeaders.OFFSET) long offset,
+            Acknowledgment ack) {
+
+        try {
+            notificationService.sendConfirmation(event);
+            ack.acknowledge();
+        } catch (Exception ex) {
+            log.error("Failed to process order event offset={}", offset, ex);
+            // Don't ack — will be retried or sent to DLT by error handler
+            throw ex;
+        }
+    }
+}
+```
+
+### Error handler with Dead Letter Topic
+```java
+@Configuration
+public class KafkaErrorHandlerConfig {
+
+    @Bean
+    public DefaultErrorHandler errorHandler(KafkaTemplate<Object, Object> template) {
+        // Retry 3 times with 1s backoff, then send to <topic>.DLT
+        DeadLetterPublishingRecoverer recoverer = new DeadLetterPublishingRecoverer(template);
+        ExponentialBackOffWithMaxRetries backOff = new ExponentialBackOffWithMaxRetries(3);
+        backOff.setInitialInterval(1000L);
+        backOff.setMultiplier(2.0);
+        return new DefaultErrorHandler(recoverer, backOff);
+    }
+}
+```
+
+---
+
+## RabbitMQ
+
+### Maven
+```xml
+<dependency>
+  <groupId>org.springframework.boot</groupId>
+  <artifactId>spring-boot-starter-amqp</artifactId>
+</dependency>
+```
+
+### application.yml
+```yaml
+spring:
+  rabbitmq:
+    host: ${RABBITMQ_HOST:localhost}
+    port: 5672
+    username: ${RABBITMQ_USER:guest}
+    password: ${RABBITMQ_PASSWORD:guest}
+    publisher-confirm-type: correlated   # for publisher confirms
+    publisher-returns: true
+    listener:
+      simple:
+        prefetch: 10                     # process 10 messages before ack
+        acknowledge-mode: manual
+```
+
+### Exchange, Queue & DLX config
+```java
+@Configuration
+public class RabbitMQConfig {
+
+    public static final String ORDER_EXCHANGE   = "orders.exchange";
+    public static final String ORDER_QUEUE      = "orders.placed";
+    public static final String ORDER_ROUTING    = "order.placed";
+    public static final String DLX_EXCHANGE     = "orders.dlx";
+    public static final String DLQ              = "orders.placed.dlq";
+
+    // Dead letter exchange
+    @Bean
+    public DirectExchange deadLetterExchange() {
+        return new DirectExchange(DLX_EXCHANGE);
+    }
+
+    @Bean
+    public Queue deadLetterQueue() {
+        return QueueBuilder.durable(DLQ).build();
+    }
+
+    @Bean
+    public Binding dlqBinding() {
+        return BindingBuilder.bind(deadLetterQueue()).to(deadLetterExchange()).with(ORDER_ROUTING);
+    }
+
+    // Main exchange and queue
+    @Bean
+    public TopicExchange orderExchange() {
+        return new TopicExchange(ORDER_EXCHANGE);
+    }
+
+    @Bean
+    public Queue orderQueue() {
+        return QueueBuilder.durable(ORDER_QUEUE)
+            .withArgument("x-dead-letter-exchange", DLX_EXCHANGE)
+            .withArgument("x-dead-letter-routing-key", ORDER_ROUTING)
+            .withArgument("x-message-ttl", 300_000)   // 5 min TTL
+            .build();
+    }
+
+    @Bean
+    public Binding orderBinding() {
+        return BindingBuilder.bind(orderQueue()).to(orderExchange()).with(ORDER_ROUTING);
+    }
+
+    // JSON message converter
+    @Bean
+    public MessageConverter jsonMessageConverter() {
+        return new Jackson2JsonMessageConverter();
+    }
+
+    @Bean
+    public RabbitTemplate rabbitTemplate(ConnectionFactory connectionFactory) {
+        RabbitTemplate template = new RabbitTemplate(connectionFactory);
+        template.setMessageConverter(jsonMessageConverter());
+        return template;
+    }
+}
+```
+
+### Publisher
+```java
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class OrderEventPublisher {
+
+    private final RabbitTemplate rabbitTemplate;
+
+    public void publishOrderPlaced(OrderPlacedEvent event) {
+        rabbitTemplate.convertAndSend(
+            RabbitMQConfig.ORDER_EXCHANGE,
+            RabbitMQConfig.ORDER_ROUTING,
+            event
+        );
+        log.debug("Published OrderPlacedEvent for order {}", event.orderId());
+    }
+}
+```
+
+### Consumer
+```java
+@Component
+@Slf4j
+public class OrderEventConsumer {
+
+    @RabbitListener(queues = RabbitMQConfig.ORDER_QUEUE)
+    public void handleOrderPlaced(
+            OrderPlacedEvent event,
+            Channel channel,
+            @Header(AmqpHeaders.DELIVERY_TAG) long deliveryTag) throws IOException {
+
+        try {
+            notificationService.sendConfirmation(event);
+            channel.basicAck(deliveryTag, false);
+        } catch (Exception ex) {
+            log.error("Failed to process order event, sending to DLQ", ex);
+            channel.basicNack(deliveryTag, false, false);  // false = don't requeue → goes to DLX
+        }
+    }
+}
+```
+
+---
+
+## Outbox Pattern (guaranteed event delivery)
+
+Prevents lost events when the service crashes after DB write but before publishing:
+
+```java
+@Entity
+@Table(name = "outbox_events")
+public class OutboxEvent {
+    @Id @GeneratedValue
+    private Long id;
+    private String aggregateType;
+    private Long aggregateId;
+    private String eventType;
+    @Column(columnDefinition = "json")
+    private String payload;
+    private boolean published = false;
+    private Instant createdAt = Instant.now();
+}
+
+// In service — save event to DB in same transaction as entity change
+@Transactional
+public Order placeOrder(OrderRequest request) {
+    Order order = orderRepository.save(Order.from(request));
+    outboxRepository.save(new OutboxEvent("Order", order.getId(), "OrderPlaced",
+        objectMapper.writeValueAsString(new OrderPlacedEvent(order.getId(), ...))));
+    return order;
+}
+
+// Scheduler polls and publishes unpublished events
+@Scheduled(fixedDelay = 1000)
+@Transactional
+public void publishPendingEvents() {
+    outboxRepository.findByPublishedFalse().forEach(event -> {
+        kafkaTemplate.send(event.getEventType(), event.getPayload());
+        event.setPublished(true);
+    });
+}
+```


### PR DESCRIPTION
Covers in-process and broker-based event-driven patterns:
- review mode: checks async listeners, @TransactionalEventListener usage, Kafka acks/DLT/idempotency, RabbitMQ durability/DLX/serialization
- app-events mode: Spring ApplicationEvent publisher + @EventListener, @Async listeners, @TransactionalEventListener(AFTER_COMMIT)
- domain-events mode: AbstractAggregateRoot.registerEvent() + save()
- kafka mode: JsonSerializer/Deserializer, manual ack, DefaultErrorHandler with DeadLetterPublishingRecoverer and exponential backoff
- rabbitmq mode: TopicExchange + durable queue + DLX setup, Jackson2JsonMessageConverter, manual basicAck/basicNack

references/patterns.md includes the Outbox Pattern for guaranteed delivery, full producer/consumer code, and DLT/DLQ configuration.